### PR TITLE
补充 pytz 依赖

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ Booktype~=1.5
 redis~=5.2.1
 tinycss2~=1.4.0
 flask_apscheduler~=1.13.1
+pytz~=2025.2


### PR DESCRIPTION
在py3.13上，它没有被自动安装